### PR TITLE
Topic/baseline tissue text length

### DIFF
--- a/root/static/js/deg_tab.js
+++ b/root/static/js/deg_tab.js
@@ -271,6 +271,9 @@ $(document).ready(function () {
   	       }
   	    }
 
+	    if (max_tissue_length < 10) {
+		max_tissue_length = 10;
+	    }
   	    adjustable_y_val = max_tissue_length * 20;
   	    var stage_lengths = [];
 

--- a/root/static/js/scatterplot_tab.js
+++ b/root/static/js/scatterplot_tab.js
@@ -332,7 +332,7 @@ $(document).ready(function () {
     if (max_tissue_length < 10) {
         max_tissue_length = 10;
     }
-    var adjustable_y_val = max_tissue_length * 20
+    var adjustable_y_val = max_tissue_length * 20;
     var stage_lengths = [];
 
     var adjustable_width = (plot_stages.length * 20) + (max_tissue_length * 30);

--- a/root/static/js/scatterplot_tab.js
+++ b/root/static/js/scatterplot_tab.js
@@ -329,6 +329,9 @@ $(document).ready(function () {
 	    }
   	}
 
+    if (max_tissue_length < 10) {
+        max_tissue_length = 10;
+    }
     var adjustable_y_val = max_tissue_length * 20
     var stage_lengths = [];
 


### PR DESCRIPTION
Minor adjustments to the selector display on the deg and scatterplot tabs, putting a minimum 'floor' for the display length of the 'tissue' labels, otherwise they get cut off if too short.